### PR TITLE
Tweaked SVG generator to produce better results

### DIFF
--- a/example/make-svg.js
+++ b/example/make-svg.js
@@ -3,11 +3,11 @@ const decode = require( '../hrm-image-decoder' )
 const linesToSvg = lines =>
   '<svg width="100%" height="100%" viewBox="0 0 65536 21845" xmlns="http://www.w3.org/2000/svg">\n' +
   lines.map( line =>
-    '<path fill="transparent" stroke="black" stroke-width="2048" stroke-linecap="round" d="' +
+    '<path fill="transparent" stroke="black" stroke-width="1920" stroke-linecap="round" stroke-linejoin="round" d="' +
     'M ' + line.map( p => {
       return p[ 0 ] + ' ' + ~~( p[ 1 ] / 3 )
     }).join( ' L ' ) +
-    '" />\n'
+    ' l 0 0" />\n'
   ) + 
   '</svg>'
 

--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,11 @@ You can then view them as SVG by doing something like:
 const linesToSvg = lines =>
   '<svg width="100%" height="100%" viewBox="0 0 65536 21845" xmlns="http://www.w3.org/2000/svg">\n' +
   lines.map( line =>
-    '<path fill="transparent" stroke="black" stroke-width="2048" stroke-linecap="round" d="' +
+    '<path fill="transparent" stroke="black" stroke-width="1920" stroke-linecap="round" stroke-linejoin="round" d="' +
     'M ' + line.map( p => {
       return p[ 0 ] + ' ' + ~~( p[ 1 ] / 3 )
     }).join( ' L ' ) +
-    '" />\n'
+    ' l 0 0" />\n'
   ) + 
   '</svg>'
 ```


### PR DESCRIPTION
- Thinner strokes and rounds line joins to match in-game style better.
- Added `"l 0 0"` at the end of paths to cause paths consisting of a single point to be drawn.

Comparison:
![comparison](https://cloud.githubusercontent.com/assets/538042/10786139/f75ab7ba-7d68-11e5-8867-44ef70b46c81.png)

Image used in comparison:

```
eNpzZAACmRBRBhYQ/mPPIALEIJplSRaDDBCDgApQzgbGBtI2QD4IuADZLiu0GHyA/BAgjgGyY4BiMUD9
LkAMAilAfgpQrgDIrwHSNVBzWoB0C5A/BYjnAPVNAcq3QPUsAYotAcrvgaq9A+QfAWGg/BUgBtFHgHJ3
oPICc16BaQOfqQwGHlchbKiYy4JVDB5A8QggjgGyI77sZwgAYai6AKi6UTAKRigAAF3XRpk;
```
